### PR TITLE
Remove golangci-lint depdency on modules.txt

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -60,7 +60,7 @@ deploy-latest:
 gitlint:
 	gitlint --commits origin/master..HEAD
 
-golangci-lint: vendor/modules.txt
+golangci-lint:
 	golangci-lint linters
 	golangci-lint run --timeout 10m
 


### PR DESCRIPTION
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>