### PR TITLE
Add OVN shared cluster_settings, using= support

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,6 +19,7 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
         cabledriver: ['libreswan']
+        cni: ['weave']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -30,6 +31,10 @@ jobs:
           # Test the same set of cable driver combinations as the consuming projects do in their CI
           - project: submariner
             cabledriver: wireguard
+            deploytool: operator
+          # OVN support is WIP, only run in main repo for now
+          - project: submariner
+            cni: ovn
             deploytool: operator
     steps:
       - name: Check out the Shipyard repository
@@ -51,6 +56,7 @@ jobs:
         uses: ./gh-actions/e2e
         with:
           cabledriver: ${{ matrix.cabledriver }}
+          cni: ${{ matrix.cni }}
           deploytool: ${{ matrix.deploytool }}
           working-directory: ./${{ matrix.project }}
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 include Makefile.inc
 
+# TODO: Remove after dependency in submariner-io/submariner is removed
+# TODO: Select OVN or Weave with the using= flag instead
 ifneq (,$(filter ovn,$(_using)))
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings.ovn
 else

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -6,6 +6,10 @@ include $(SHIPYARD_DIR)/Makefile.versions
 
 # Process extra flags from the `using=a,b,c` optional flag
 
+ifneq (,$(filter ovn,$(_using)))
+override CLUSTERS_ARGS +=  --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings.ovn
+endif
+
 ifneq (,$(filter libreswan,$(_using)))
 override DEPLOY_ARGS += --cable_driver libreswan
 else ifneq (,$(filter strongswan,$(_using)))

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -10,6 +10,9 @@ inputs:
   globalnet:
     description: 'Should the deployment be with globalnet or not'
     required: false
+  cni:
+    description: 'CNI implementation to use when creating clusters'
+    required: false
   working-directory:
     description: 'Working directory to run in'
     required: false
@@ -44,4 +47,4 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        make e2e using="${{ inputs.globalnet }} ${{ inputs.deploytool }} ${{ inputs.cabledriver }}"
+        make e2e using="${{ inputs.globalnet }} ${{ inputs.deploytool }} ${{ inputs.cabledriver }} ${{ matrix.cni }}"

--- a/scripts/shared/lib/cluster_settings
+++ b/scripts/shared/lib/cluster_settings
@@ -28,8 +28,8 @@ cluster_subm['cluster3']="true"
 
 # Map of cluster names to values specifying which CNI to install.
 # Empty (or not set) value means default CNI.
-# Currently only "weave" is supported.
 declare -gA cluster_cni
 
+cluster_cni['cluster1']="weave"
 cluster_cni['cluster2']="weave"
 cluster_cni['cluster3']="weave"

--- a/scripts/shared/lib/cluster_settings.ovn
+++ b/scripts/shared/lib/cluster_settings.ovn
@@ -1,0 +1,6 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034 # We declare some shared variables here
+
+cluster_cni['cluster1']="ovn"
+cluster_cni['cluster2']="ovn"
+cluster_cni['cluster3']="ovn"


### PR DESCRIPTION
Split the default cluster CNI settings into OVN or Weave options,
selectable by `using=ovn` or `using=weave` (default).

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>