### PR TITLE
Improve post-mortem logging, list resources better

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -24,8 +24,10 @@ function print_pods_logs() {
 }
 
 function post_analyze() {
+    print_section "* All resources in $cluster *"
+    kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --show-kind -o wide --ignore-not-found
+
     print_section "* Pods not running in $cluster *"
-    kubectl get all --all-namespaces
     for pod in $(kubectl get pods -A | tail -n +2 | grep -v Running | sed 's/  */;/g'); do
         ns=$(echo $pod | cut -f1 -d';')
         name=$(echo $pod | cut -f2 -d';')


### PR DESCRIPTION
List all available API resources in post mortem, vs only the subset
covered by `kubectl get all`.

Also group listing all resources independently of group for listing any
not-running Pods.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>