### PR TITLE
Disaggregate consumer linting for full coverage

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -102,8 +102,47 @@ jobs:
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
 
-      - name: Run all linters
-        run: make -C ${{ matrix.project }} lint
+      - name: Run gitlint
+        if: always()
+        run: make -C ${{ matrix.project }} gitlint
+
+      - name: Run golangci-lint
+        if: ${{ always() && matrix.project != 'submariner-charts' }}
+        run: make -C ${{ matrix.project }} golangci-lint
+
+      - name: Run markdownlint
+        if: always()
+        run: make -C ${{ matrix.project }} markdownlint
+
+      - name: Run packagedoc-lint
+        if: >-
+          ${{
+          always()
+          && matrix.project != 'cloud-prepare'
+          && matrix.project != 'coastguard'
+          && matrix.project != 'lighthouse'
+          && matrix.project != 'submariner-charts'
+          && matrix.project != 'submariner-operator'
+          }}
+        run: make -C ${{ matrix.project }} packagedoc-lint
+
+      - name: Run shellcheck
+        if: >-
+          ${{
+          always()
+          && matrix.project != 'admiral'
+          && matrix.project != 'cloud-prepare'
+          && matrix.project != 'coastguard'
+          && matrix.project != 'lighthouse'
+          && matrix.project != 'submariner'
+          && matrix.project != 'submariner-charts'
+          && matrix.project != 'submariner-operator'
+          }}
+        run: make -C ${{ matrix.project }} shellcheck
+
+      - name: Run yamllint
+        if: ${{ always() && matrix.project != 'submariner-charts' }}
+        run: make -C ${{ matrix.project }} yamllint
 
   unit-consuming:
     name: Unit Tests

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -148,7 +148,7 @@ deploy-latest:
 	$(MAKE) -o images -o preload-images deploy SUBCTL=~/.local/bin/subctl DEV_VERSION=latest CUTTING_EDGE=latest VERSION=latest DEPLOY_ARGS="$(DEPLOY_ARGS) --image_tag=subctl" using=$(using)
 
 ##### LINTING TARGETS #####
-.PHONY: gitlint golangci-lint lint markdownlint packagedoc-lint shellcheck yamllint
+.PHONY: gitlint golangci-lint markdownlint packagedoc-lint shellcheck yamllint
 
 # [gitlint] validates the commits are valid
 gitlint:
@@ -166,6 +166,14 @@ golangci-lint: $(VENDOR_MODULES)
 	golangci-lint linters
 	golangci-lint run --timeout 10m
 
+# [markdownlint] validates Markdown files in the project
+markdownlint:
+	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
+	if [ -r .mdignore ]; then \
+		md_ignored+=($$(< .mdignore)); \
+	fi; \
+	markdownlint -c .markdownlint.yml $${md_ignored[@]/#/-i } .
+
 # [packagedoc-lint] checks that the package docs don’t include the SPDX header
 packagedoc-lint:
 	result=0; \
@@ -176,16 +184,6 @@ packagedoc-lint:
 		fi; \
 	done 2>/dev/null; \
 	exit $$result
-
-lint: gitlint golangci-lint markdownlint yamllint
-
-# [markdownlint] validates Markdown files in the project
-markdownlint:
-	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
-	if [ -r .mdignore ]; then \
-		md_ignored+=($$(< .mdignore)); \
-	fi; \
-	markdownlint -c .markdownlint.yml $${md_ignored[@]/#/-i } .
 
 # [shellcheck] validates your shell files
 shellcheck:


### PR DESCRIPTION
For better coverage, clearer maintenance, and more readable log output.

This also removes the `make lint` target. Per discussion on #739, it
isn't used by devs and causes unclear maintenance that can result in
gaps in test coverage.

I looked at doing this by using per-project linter jobs and a custom
GitHub Action for the logic that can be extracted. Because we can't use
other GHAs in custom GHAs, we can't extract actions/checkout or would
have to create custom git logic to extract the two checkout steps.
Splitting each desired linter/project combo into a job results in lots
of duplicated GHA boilerplate. It also wastes resources re-doing things
like building the Shipyard image. Splitting each project into a parallel
job and clearly separating the linting runs in the output using steps
seems like the best solution overall.

Also reorder markdownlint make target for consistent ABC ordering.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>