### PR TITLE
Use openshifttest/nginx-alpine for rootless E2E

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/testing-farm/nginx:latest
+          image: quay.io/openshifttest/nginx-alpine:latest
           ports:
             - containerPort: 80
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/testing-farm/nginx:latest",
+							Image:           "quay.io/openshifttest/nginx-alpine:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
To fix support for running E2E tests using an nginx web server container
in OpenShift, which only allows running rootless containers.

The quay.io/bitnami/nginx image we used for a long time was rootless but
has been removed. The quay.io/testing-farm/nginx mirror of the official
nginx containers on DockerHub is not rootless. The official rootless
container nginxinc/nginx-unprivileged is on DockerHub but has no mirror
to Quay. The agnhost K8s CI tool's netexec or nettest commands might be
useful, but would require more retooling.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>